### PR TITLE
Fix status key in users filter endpoint

### DIFF
--- a/Microservices/Users(1406)/routers/get.py
+++ b/Microservices/Users(1406)/routers/get.py
@@ -23,7 +23,7 @@ async def get_all_users():
 async def get_users_with_params(*, skip: int, limit: int):
     _, result = await db.get_documents(skip=skip, limit=limit)
     return {
-        'statuts': 'OK',
+        'status': 'OK',
         'result': result
     }
 


### PR DESCRIPTION
## Summary
- correct `statuts` typo to `status` in Users service

## Testing
- `pytest -q`
- manual check via Python script to ensure `get_users_with_params` returns `status` field

------
https://chatgpt.com/codex/tasks/task_e_68470ae3838c83328d7d1051b0ead0a5