### PR TITLE
Fix docstring typo

### DIFF
--- a/Microservices/API(1400)/routers/users/post.py
+++ b/Microservices/API(1400)/routers/users/post.py
@@ -13,7 +13,7 @@ async def create_user_avatar(syncId: int, file: UploadFile):
     """
     {
         'status': 'OK',
-        'resutl': str (filename)
+        'result': str (filename)
     }
     """
     file_bytes = await file.read()


### PR DESCRIPTION
## Summary
- correct `resutl` typo in create_user_avatar docstring

## Testing
- `grep -R "resut" -n`

------
https://chatgpt.com/codex/tasks/task_e_68470afd80e883328ea133ac10ca1df9